### PR TITLE
add resource estimate to boutiques descriptor bst-tool.json

### DIFF
--- a/boutiques_descriptors/bst-tool.json
+++ b/boutiques_descriptors/bst-tool.json
@@ -33,9 +33,13 @@
             "id": "output_directory",
             "name": "Output Directory",
             "optional": false,
-            "description": "Output directory.",
+            "description": "Output directory",
             "path-template": "[BIDS_DATASET]_output"
         }
     ],
+    "suggested-resources": {
+            "walltime-estimate": 10800,
+            "ram": 8
+    },
     "doi": "10.5072/zenodo.1182898"
 }


### PR DESCRIPTION
Resource estimate can help running tool on HPC
